### PR TITLE
Fix publish docs for branches

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -77,6 +77,15 @@ jobs:
           python3 -m pip install breathe
           python3 -m pip install pygments
 
+      - name: Set docs target name
+        shell: bash
+        run: |
+            if [[ ${{ github.ref_name }} == *"/merge" ]]; then
+              echo "AVM_DOCS_NAME=${{github.event.pull_request.base.ref}}" >> "$GITHUB_ENV";
+            else
+              echo "AVM_DOCS_NAME=${{ github.ref_name }}" >> "$GITHUB_ENV";
+            fi
+
       - uses: actions/checkout@v4
         with:
           repository: ${{ vars.GITHUB_REPOSITORY }}

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -38,6 +38,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
+    env:
+      AVM_DOCS_NAME: ${{ github.ref_name }}
+
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -58,16 +58,8 @@ add_custom_target(edown-escript
 
 # Get the version tree name, tag if this is a tagged commit, otherwise get the current branch name.
 if ($ENV{CI})
-    if (NOT (DEFINED ENV{GITHUB_BASE_REF}) AND ($ENV{GITHUB_REPOSITORY} STREQUAL "atomvm/AtomVM"))
-        set(DOC_TREE_VERSION $ENV{GITHUB_REF_NAME})
-        message("CI Publishing documentation for ${DOC_TREE_VERSION}")
-    elseif ($ENV{GITHUB_REPOSITORY} STREQUAL "atomvm/AtomVM")
-        set(DOC_TREE_VERSION $ENV{GITHUB_HEAD_REF})
-        message("CI Test building documentation for ${DOC_TREE_VERSION}")
-    else()
-        set(DOC_TREE_VERSION $ENV{GITHUB_REF_NAME})
-        message("CI Test building documentation for $ENV{GITHUB_REPOSITORY} on branch ${DOC_TREE_VERSION}")
-    endif (NOT (DEFINED ENV{GITHUB_BASE_REF}) AND ($ENV{GITHUB_REPOSITORY} STREQUAL "atomvm/AtomVM"))
+    set(DOC_TREE_VERSION $ENV{AVM_DOCS_NAME})
+    message("CI building documentation for target branch ${DOC_TREE_VERSION}")
 else()
     execute_process(COMMAND "bash" "-c" "tag=$(git for-each-ref --points-at=HEAD --format='%(refname:lstrip=2)' refs/tags); ( [ $tag ] && echo $tag )|| git branch --show-current"
                     OUTPUT_VARIABLE


### PR DESCRIPTION
There was a bug in the tests for GitHub environment variables that led to the build system using the push rule rather than the merge rule for determining the branch name, in this case using an undefined environment variable which resulted in an empty branch name. Determining the correct branch or tag name from within cmake using GitHub environment variables is unreliable, so instead the correct name is determined by the workflows, which set an environment variable that can be used by cmake.

These changes are made under both the "Apache 2.0" and the "GNU Lesser General
Public License 2.1 or later" license terms (dual license).

SPDX-License-Identifier: Apache-2.0 OR LGPL-2.1-or-later
